### PR TITLE
Fixed dependecy errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/react-redux": "4.4.47",
     "@types/redux-logger": "2.6.31",
     "@types/redux-thunk": "2.1.30",
+    "@types/tapable": "^0.2.5",
     "@types/webpack": "3.0.5",
     "@types/webpack-dev-server": "2.4.1",
     "autoprefixer": "7.1.2",


### PR DESCRIPTION
After running `npm-install` and `npm-start` I ran into [this issue](https://github.com/webpack/tapable/issues/53#issuecomment-378772767). I've fixed it according to the conclusion they reached, by adding types@tapable-0.2.5 as a dev dependency. 

Might be a valuable fix for future datavetare looking to fiddle with the frontend?